### PR TITLE
Feature/syslog collection server

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -98,6 +98,16 @@ auth:
   mfa_secret_key: h5/dLmo1H/OFCjNs2SqTyD5XLL3u7EJy/ipHzf4Ej6c=     # Base64 encoded, at least length 32
   jwt_secret: fV3kTO3e3sP/t+xCe4jC0fj76RSSg5WXRL7CcTGmzxo=         # Base64 encoded, at least length 32
 
+syslog_collection:
+  tcp_enabled: true
+  udp_enabled: true
+  tcp_port: 514
+  udp_port: 514
+  tcp_address: 0.0.0.0
+  udp_address: 0.0.0.0
+  tcp_buffer_size: 1024
+  udp_buffer_size: 1024
+
 buffer_engine:
   enabled: true
   flush_interval: 5s             # Global flush interval for all stores

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aaronlmathis/gosight-server
 go 1.23.7
 
 require (
-	github.com/aaronlmathis/gosight-shared v0.0.0-20250513191055-0380956c32cb
+	github.com/aaronlmathis/gosight-shared v0.0.0-20250519003907-ebb180193644
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go/compute/metadata v0.6.0 h1:A6hENjEsCDtC1k8byVsgwvVcioamEHvZ4j01OwKxG9I=
 cloud.google.com/go/compute/metadata v0.6.0/go.mod h1:FjyFAW1MW0C203CEOMDTu3Dk1FlqW3Rga40jzHL4hfg=
-github.com/aaronlmathis/gosight-shared v0.0.0-20250513191055-0380956c32cb h1:Ssu3YHPSE5LGuiHQ1Nr3zZkhUlGefRNA7HSYysH1C3Y=
-github.com/aaronlmathis/gosight-shared v0.0.0-20250513191055-0380956c32cb/go.mod h1:MrTO9x8sa8hcRf5D9Gy3x0/tZTaYjEpQU8166Vz6m5Y=
+github.com/aaronlmathis/gosight-shared v0.0.0-20250519003907-ebb180193644 h1:7cUZKt1nuIXtmAdK2px+huhyT57EsgliQYPrjgi633Y=
+github.com/aaronlmathis/gosight-shared v0.0.0-20250519003907-ebb180193644/go.mod h1:MrTO9x8sa8hcRf5D9Gy3x0/tZTaYjEpQU8166Vz6m5Y=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=

--- a/internal/bootstrap/init.go
+++ b/internal/bootstrap/init.go
@@ -116,7 +116,7 @@ func InitGoSight(ctx context.Context) (*sys.SystemContext, error) {
 	// Initialize cache
 	caches, err := InitCaches(ctx, dataStore)
 	utils.Must("Caches", err)
-
+	fmt.Printf(">>> caches.Logs = %#v (type %T)\n", caches.Logs, caches.Logs)
 	// Init metric store
 	metricStore, err := InitMetricStore(ctx, cfg, caches.Metrics)
 	utils.Must("Metric store", err)

--- a/internal/cache/logcache.go
+++ b/internal/cache/logcache.go
@@ -59,16 +59,22 @@ func (c *logCache) Add(batch []*model.StoredLog) {
 	defer c.mu.Unlock()
 
 	for _, storedLog := range batch {
+		if storedLog == nil {
+			utils.Warn("logCache.Add: nil StoredLog in batch")
+			continue
+		}
 		if storedLog.LogID == "" {
 			utils.Warn("log entry found with no LogID")
+			continue
+		}
+		if storedLog.Meta == nil {
+			utils.Warn("log entry found with nil Meta")
 			continue
 		}
 		utils.Debug("Adding logcache: %v", storedLog.Meta.EndpointID)
 		c.store[storedLog.LogID] = storedLog
 		c.endpoints[storedLog.Meta.EndpointID] = struct{}{}
-
 	}
-
 }
 
 func (c *logCache) Get(logID string) (*model.LogEntry, bool) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -133,6 +133,8 @@ type Config struct {
 
 	BufferEngine BufferEngineConfig `yaml:"buffer_engine"`
 
+	SyslogCollection SyslogCollectionConfig `yaml:"syslog_collection"`
+
 	Auth struct {
 		SSOEnabled bool         `yaml:"sso_enabled"`
 		MFASecret  string       `yaml:"mfa_secret_key"`
@@ -142,6 +144,19 @@ type Config struct {
 		Azure      AzureConfig  `yaml:"azure"`
 		GitHub     GitHubConfig `yaml:"github"`
 	} `yaml:"auth"`
+}
+
+// SyslogCollectionConfig defines the configuration for syslog collection
+// The syslog collection can be used to collect syslog messages from network devices.
+type SyslogCollectionConfig struct {
+	TCPEnabled     bool `yaml:"tcp_enabled"`
+	UDPEnabled     bool `yaml:"udp_enabled"`
+	TCPPort        int  `yaml:"tcp_port"`
+	UDPPort        int  `yaml:"udp_port"`
+	TCPBufferSize  int  `yaml:"tcp_buffer_size"`
+	UDPBufferSize  int  `yaml:"udp_buffer_size"`
+	MaxConnections int  `yaml:"max_connections"`
+	DefaultIPLimit int  `yaml:"default_ip_limit"`
 }
 
 // GoogleConfig represents the configuration for Google OAuth2 authentication.

--- a/internal/store/datastore/datastore.go
+++ b/internal/store/datastore/datastore.go
@@ -61,6 +61,10 @@ type DataStore interface {
 	InsertProcessInfos(ctx context.Context, snapshotID int64, payload *model.ProcessPayload) error
 	QueryProcessInfos(ctx context.Context, filter *model.ProcessQueryFilter) ([]model.ProcessInfo, error)
 
+	// Syslog methods
+	GetNetworkDevices(ctx context.Context) ([]*model.NetworkDevice, error)
+	GetNetworkDeviceByAddress(ctx context.Context, address string) (*model.NetworkDevice, error)
+
 	// Lifecycle
 	Close() error
 }

--- a/internal/store/datastore/pgsql/networkdevices.go
+++ b/internal/store/datastore/pgsql/networkdevices.go
@@ -1,0 +1,117 @@
+/*
+SPDX-License-Identifier: GPL-3.0-or-later
+
+Copyright (C) 2025 Aaron Mathis aaron.mathis@gmail.com
+
+This file is part of GoSight.
+
+GoSight is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+GoSight is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GoSight. If not, see https://www.gnu.org/licenses/.
+*/
+
+package pgstore
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/aaronlmathis/gosight-shared/model"
+)
+
+// GetNetworkDevices returns all network devices from the database
+func (s *PGDataStore) GetNetworkDevices(ctx context.Context) ([]*model.NetworkDevice, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, name, vendor, address, port, protocol, format, facility, syslog_id, rate_limit, created_at, updated_at
+		FROM network_devices
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("query failed: %w", err)
+	}
+	defer rows.Close()
+
+	var networkDevices []*model.NetworkDevice
+
+	for rows.Next() {
+		var networkDevice model.NetworkDevice
+		var createdAt, updatedAt time.Time
+
+		if err := rows.Scan(
+			&networkDevice.ID,
+			&networkDevice.Name,
+			&networkDevice.Vendor,
+			&networkDevice.Address,
+			&networkDevice.Port,
+			&networkDevice.Protocol,
+			&networkDevice.Format,
+			&networkDevice.Facility,
+			&networkDevice.SyslogID,
+			&networkDevice.RateLimit,
+			&createdAt,
+			&updatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan failed: %w", err)
+		}
+
+		networkDevice.CreatedAt = createdAt
+		networkDevice.UpdatedAt = updatedAt
+		networkDevices = append(networkDevices, &networkDevice)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows iteration error: %w", err)
+	}
+
+	return networkDevices, nil
+}
+
+// GetNetworkDeviceByAddress looks up a single NetworkDevice by its IP/hostname.
+// Returns (nil, nil) if no matching device is found.
+func (s *PGDataStore) GetNetworkDeviceByAddress(ctx context.Context, address string) (*model.NetworkDevice, error) {
+	const q = `
+        SELECT id, name, vendor, address, port, protocol, format, facility, syslog_id, rate_limit, created_at, updated_at
+        FROM network_devices
+        WHERE address = $1
+        LIMIT 1
+    `
+
+	row := s.db.QueryRowContext(ctx, q, address)
+
+	var nd model.NetworkDevice
+	var createdAt, updatedAt time.Time
+
+	if err := row.Scan(
+		&nd.ID,
+		&nd.Name,
+		&nd.Vendor,
+		&nd.Address,
+		&nd.Port,
+		&nd.Protocol,
+		&nd.Format,
+		&nd.Facility,
+		&nd.SyslogID,
+		&nd.RateLimit,
+		&createdAt,
+		&updatedAt,
+	); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("GetNetworkDeviceByAddress scan failed: %w", err)
+	}
+
+	nd.CreatedAt = createdAt
+	nd.UpdatedAt = updatedAt
+	return &nd, nil
+}

--- a/internal/store/logstore/victoriametrics/victoriametrics.go
+++ b/internal/store/logstore/victoriametrics/victoriametrics.go
@@ -65,9 +65,12 @@ func (v *VictoriaLogStore) Write(batch []model.LogPayload) error {
 	// Wrap all logs once — generates log_id and preserves Meta
 	wrapped := wrapLogs(batch)
 
-	// Store in cache
-	v.cache.Add(wrapped)
-
+	if v.cache == nil {
+		utils.Debug("VictoriaLogStore: cached is nil")
+	} else {
+		// Store in cache
+		v.cache.Add(wrapped)
+	}
 	// Write full logs to compressed JSON (one entry per line)
 	if err := v.writeCompressedWrappedLogs(wrapped); err != nil {
 		utils.Warn("Failed to write logs to JSON: %v", err)

--- a/internal/syslog/doc.go
+++ b/internal/syslog/doc.go
@@ -1,0 +1,23 @@
+/*
+SPDX-License-Identifier: GPL-3.0-or-later
+
+Copyright (C) 2025 Aaron Mathis aaron.mathis@gmail.com
+
+This file is part of GoSight.
+
+GoSight is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+GoSight is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GoSight. If not, see https://www.gnu.org/licenses/.
+*/
+
+// Package syslog provides a syslog server implementation to receive syslog messages from network clients
+package syslog

--- a/internal/syslog/handlelog.go
+++ b/internal/syslog/handlelog.go
@@ -1,0 +1,89 @@
+/*
+SPDX-License-Identifier: GPL-3.0-or-later
+
+Copyright (C) 2025 Aaron Mathis aaron.mathis@gmail.com
+
+This file is part of GoSight.
+
+GoSight is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+GoSight is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GoSight. If not, see https://www.gnu.org/licenses/.
+*/
+
+package syslog
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/aaronlmathis/gosight-shared/model"
+)
+
+// handleLog parses raw syslog data, builds a LogPayload, and writes it to the buffer.
+func (s *SyslogServer) handleLog(ctx context.Context, raw []byte, srcAddr string) {
+	ts := time.Now()
+
+	// Simple parser stub; replace with full RFC3164/5424/CEF logic
+	host, facility, severity, msg, fields := parseSyslog(raw)
+
+	// Lookup device by source address
+	dev, _ := s.sys.Stores.Data.GetNetworkDeviceByAddress(ctx, srcAddr)
+	deviceID, deviceName := "", ""
+	if dev != nil {
+		deviceID = dev.ID
+		deviceName = dev.Name
+	}
+
+	// Build the LogEntry
+	entry := model.LogEntry{
+		Timestamp: ts,
+		Level:     severity,
+		Message:   msg,
+		Source:    facility,
+		Category:  "network",
+		Fields:    fields,
+		Tags: map[string]string{
+			"device_id":   deviceID,
+			"device_name": deviceName,
+			"src_ip":      srcAddr,
+		},
+		Meta: &model.LogMeta{
+			Platform: "syslog",
+			Service:  deviceName,
+		},
+	}
+
+	// Wrap in a LogPayload
+	payload := model.LogPayload{
+		AgentID:    "",
+		HostID:     "",
+		Hostname:   host,
+		EndpointID: deviceID,
+		Timestamp:  ts,
+		Logs:       []model.LogEntry{entry},
+		Meta:       nil,
+	}
+
+	// Write into the shared log buffer
+	s.sys.Buffers.Logs.WriteAny(payload)
+}
+
+// parseSyslog is a placeholder parser for raw syslog messages.
+func parseSyslog(raw []byte) (host, facility, severity, message string, fields map[string]string) {
+	fields = make(map[string]string)
+	message = strings.TrimSpace(string(raw))
+	host = ""
+	facility = "syslog"
+	severity = "info"
+	return
+}

--- a/internal/syslog/handlelog.go
+++ b/internal/syslog/handlelog.go
@@ -23,14 +23,17 @@ package syslog
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
 	"github.com/aaronlmathis/gosight-shared/model"
+	"github.com/aaronlmathis/gosight-shared/utils"
 )
 
 // handleLog parses raw syslog data, builds a LogPayload, and writes it to the buffer.
 func (s *SyslogServer) handleLog(ctx context.Context, raw []byte, srcAddr string) {
+	utils.Debug("Handling log from %s", srcAddr)
 	ts := time.Now()
 
 	// Simple parser stub; replace with full RFC3164/5424/CEF logic
@@ -62,7 +65,13 @@ func (s *SyslogServer) handleLog(ctx context.Context, raw []byte, srcAddr string
 			Service:  deviceName,
 		},
 	}
-
+	meta := &model.Meta{
+		Hostname:   host,
+		EndpointID: deviceID,
+		Platform:   "syslog",
+		Service:    deviceName,
+		IPAddress:  srcAddr,
+	}
 	// Wrap in a LogPayload
 	payload := model.LogPayload{
 		AgentID:    "",
@@ -71,19 +80,253 @@ func (s *SyslogServer) handleLog(ctx context.Context, raw []byte, srcAddr string
 		EndpointID: deviceID,
 		Timestamp:  ts,
 		Logs:       []model.LogEntry{entry},
-		Meta:       nil,
+		Meta:       meta,
 	}
 
 	// Write into the shared log buffer
 	s.sys.Buffers.Logs.WriteAny(payload)
 }
 
-// parseSyslog is a placeholder parser for raw syslog messages.
+// SyslogFormat represents the detected format of a syslog message
+type SyslogFormat int
+
+const (
+	FormatUnknown SyslogFormat = iota
+	FormatRFC3164
+	FormatRFC5424
+	FormatCEF
+)
+
+// parseSyslog parses raw syslog messages in RFC3164, RFC5424, or CEF format
 func parseSyslog(raw []byte) (host, facility, severity, message string, fields map[string]string) {
 	fields = make(map[string]string)
-	message = strings.TrimSpace(string(raw))
+	msg := strings.TrimSpace(string(raw))
+
+	// Default values
 	host = ""
 	facility = "syslog"
 	severity = "info"
+	message = msg
+
+	// Detect format
+	format := detectFormat(msg)
+
+	switch format {
+	case FormatRFC5424:
+		return parseRFC5424(msg)
+	case FormatRFC3164:
+		return parseRFC3164(msg)
+	case FormatCEF:
+		return parseCEF(msg)
+	}
+
 	return
+}
+
+// detectFormat determines the syslog format based on message characteristics
+func detectFormat(msg string) SyslogFormat {
+	if strings.HasPrefix(msg, "<") {
+		if strings.Contains(msg, "1 ") && strings.Count(msg, "|") == 0 { // RFC5424 has version "1 "
+			return FormatRFC5424
+		}
+		return FormatRFC3164 // Assume RFC3164 if it starts with PRI but isn't RFC5424
+	}
+	if strings.Contains(msg, "CEF:") {
+		return FormatCEF
+	}
+	return FormatUnknown
+}
+
+// parseRFC5424 parses a message in RFC5424 format
+// Example: <34>1 2003-10-11T22:14:15.003Z mymachine.example.com su - ID47 - MSG
+func parseRFC5424(msg string) (host, facility, severity, message string, fields map[string]string) {
+	fields = make(map[string]string)
+
+	// Extract PRI
+	priEnd := strings.Index(msg, ">")
+	if priEnd == -1 || priEnd > 5 {
+		return "", "syslog", "info", msg, fields
+	}
+
+	pri := msg[1:priEnd]
+	priNum := 0
+	fmt.Sscanf(pri, "%d", &priNum)
+
+	facilityNum := priNum / 8
+	severityNum := priNum % 8
+
+	facility = getFacilityString(facilityNum)
+	severity = getSeverityString(severityNum)
+
+	// Split remaining parts
+	parts := strings.SplitN(msg[priEnd+1:], " ", 7)
+	if len(parts) < 7 {
+		return "", facility, severity, msg, fields
+	}
+
+	// Extract components
+	fields["version"] = parts[0]
+	fields["timestamp"] = parts[1]
+	host = parts[2]
+	fields["app_name"] = parts[3]
+	fields["proc_id"] = parts[4]
+	fields["msg_id"] = parts[5]
+	message = parts[6]
+
+	return
+}
+
+// parseRFC3164 parses a message in RFC3164 (BSD) format
+// Example: <13>Feb  5 17:32:18 10.0.0.99 myproc[10]: Use the BFG!
+func parseRFC3164(msg string) (host, facility, severity, message string, fields map[string]string) {
+	fields = make(map[string]string)
+
+	// Extract PRI
+	priEnd := strings.Index(msg, ">")
+	if priEnd == -1 || priEnd > 5 {
+		return "", "syslog", "info", msg, fields
+	}
+
+	pri := msg[1:priEnd]
+	priNum := 0
+	fmt.Sscanf(pri, "%d", &priNum)
+
+	facilityNum := priNum / 8
+	severityNum := priNum % 8
+
+	facility = getFacilityString(facilityNum)
+	severity = getSeverityString(severityNum)
+
+	// Parse timestamp and hostname
+	parts := strings.SplitN(msg[priEnd+1:], " ", 4)
+	if len(parts) < 4 {
+		return "", facility, severity, msg, fields
+	}
+
+	timestamp := strings.Join(parts[0:3], " ")
+	fields["timestamp"] = timestamp
+
+	// Extract hostname and message
+	remainder := parts[3]
+	hostEnd := strings.Index(remainder, " ")
+	if hostEnd == -1 {
+		return "", facility, severity, remainder, fields
+	}
+
+	host = remainder[:hostEnd]
+	message = strings.TrimSpace(remainder[hostEnd+1:])
+
+	// Extract process info if present
+	if procStart := strings.Index(message, "["); procStart != -1 {
+		if procEnd := strings.Index(message[procStart:], "]"); procEnd != -1 {
+			fields["process"] = message[:procStart]
+			fields["pid"] = message[procStart+1 : procStart+procEnd]
+			message = strings.TrimSpace(message[procStart+procEnd+2:]) // +2 to skip "]: "
+		}
+	}
+
+	return
+}
+
+// parseCEF parses a message in CEF format
+// Example: CEF:Version|Device Vendor|Device Product|Device Version|Signature ID|Name|Severity|Extension
+func parseCEF(msg string) (host, facility, severity, message string, fields map[string]string) {
+	fields = make(map[string]string)
+
+	// Check for CEF prefix
+	cefStart := strings.Index(msg, "CEF:")
+	if cefStart == -1 {
+		return "", "syslog", "info", msg, fields
+	}
+
+	// Extract header if present (everything before CEF:)
+	if cefStart > 0 {
+		header := msg[:cefStart]
+		// Try to parse header as RFC3164
+		host, facility, severity, _, _ = parseRFC3164(header)
+	}
+
+	// Parse CEF parts
+	parts := strings.Split(msg[cefStart+4:], "|")
+	if len(parts) < 7 {
+		return host, facility, severity, msg, fields
+	}
+
+	// Standard CEF fields
+	fields["cef_version"] = parts[0]
+	fields["device_vendor"] = parts[1]
+	fields["device_product"] = parts[2]
+	fields["device_version"] = parts[3]
+	fields["signature_id"] = parts[4]
+	fields["name"] = parts[5]
+	fields["severity"] = parts[6]
+
+	// Parse extension fields if present
+	if len(parts) > 7 {
+		message = parts[7]
+		// Parse key-value pairs in extensions
+		pairs := strings.Split(parts[7], " ")
+		for _, pair := range pairs {
+			if strings.Contains(pair, "=") {
+				kv := strings.SplitN(pair, "=", 2)
+				if len(kv) == 2 {
+					fields[kv[0]] = kv[1]
+				}
+			}
+		}
+	}
+
+	return
+}
+
+// getFacilityString converts a facility number to its string representation
+func getFacilityString(facility int) string {
+	facilities := map[int]string{
+		0:  "kern",
+		1:  "user",
+		2:  "mail",
+		3:  "daemon",
+		4:  "auth",
+		5:  "syslog",
+		6:  "lpr",
+		7:  "news",
+		8:  "uucp",
+		9:  "cron",
+		10: "authpriv",
+		11: "ftp",
+		12: "ntp",
+		13: "security",
+		14: "console",
+		15: "mark",
+		16: "local0",
+		17: "local1",
+		18: "local2",
+		19: "local3",
+		20: "local4",
+		21: "local5",
+		22: "local6",
+		23: "local7",
+	}
+	if name, ok := facilities[facility]; ok {
+		return name
+	}
+	return "unknown"
+}
+
+// getSeverityString converts a severity number to its string representation
+func getSeverityString(severity int) string {
+	severities := map[int]string{
+		0: "emergency",
+		1: "alert",
+		2: "critical",
+		3: "error",
+		4: "warning",
+		5: "notice",
+		6: "info",
+		7: "debug",
+	}
+	if name, ok := severities[severity]; ok {
+		return name
+	}
+	return "unknown"
 }

--- a/internal/syslog/syslog.go
+++ b/internal/syslog/syslog.go
@@ -1,0 +1,244 @@
+/*
+SPDX-License-Identifier: GPL-3.0-or-later
+
+Copyright (C) 2025 Aaron Mathis aaron.mathis@gmail.com
+
+This file is part of GoSight.
+
+GoSight is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+GoSight is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GoSight. If not, see https://www.gnu.org/licenses/.
+*/
+
+package syslog
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/aaronlmathis/gosight-server/internal/sys"
+	"github.com/aaronlmathis/gosight-shared/model"
+)
+
+type SyslogServer struct {
+	listener          net.Listener
+	sys               *sys.SystemContext
+	wg                sync.WaitGroup
+	NetworkDevices    []*model.NetworkDevice
+	maxConnections    int
+	activeConnections int
+	connectionMutex   sync.Mutex
+	ipConnections     map[string]int
+	ipLimits          map[string]int // Optional per-IP limits
+	defaultIPLimit    int
+}
+
+// NewSyslogServer creates a new SyslogServer instance
+func NewSyslogServer(sys *sys.SystemContext) (*SyslogServer, error) {
+
+	networkDevices, err := sys.Stores.Data.GetNetworkDevices(sys.Ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get network devices: %w", err)
+	}
+
+	var maxConnections, defaultIPLimit int
+	if sys.Cfg.SyslogCollection.MaxConnections < 1 {
+		maxConnections = 500
+	} else {
+		maxConnections = sys.Cfg.SyslogCollection.MaxConnections
+	}
+
+	if sys.Cfg.SyslogCollection.DefaultIPLimit < 1 {
+		defaultIPLimit = 10
+	} else {
+		defaultIPLimit = sys.Cfg.SyslogCollection.DefaultIPLimit
+	}
+
+	return &SyslogServer{
+		sys:               sys,
+		NetworkDevices:    networkDevices,
+		maxConnections:    maxConnections,
+		activeConnections: 0,
+		ipConnections:     make(map[string]int),
+		ipLimits:          make(map[string]int),
+		defaultIPLimit:    defaultIPLimit,
+	}, nil
+}
+
+// Start binds sockets, wires context cancellation, then spins up the two listeners.
+func (s *SyslogServer) Start() error {
+
+	// Bind sockets
+	udpConn, err := net.ListenPacket("udp", fmt.Sprintf(":%d", s.sys.Cfg.SyslogCollection.UDPPort))
+	if err != nil {
+		return fmt.Errorf("failed to listen on UDP: %w", err)
+	}
+	tcpLn, err := net.Listen("tcp", fmt.Sprintf(":%d", s.sys.Cfg.SyslogCollection.TCPPort))
+	if err != nil {
+		udpConn.Close()
+		return fmt.Errorf("failed to listen on TCP: %w", err)
+	}
+
+	// When context is done, close both sockets to unblock Read/Accept
+	go func() {
+		<-s.sys.Ctx.Done()
+		udpConn.Close()
+		tcpLn.Close()
+	}()
+
+	// Launch UDP listener
+	s.wg.Add(1)
+	go s.listenUDP(s.sys.Ctx, udpConn)
+
+	// Launch TCP listener
+	s.wg.Add(1)
+	go s.listenTCP(s.sys.Ctx, tcpLn)
+
+	return nil
+}
+
+// listenUDP reads packets until ctx is canceled or the socket is closed.
+func (s *SyslogServer) listenUDP(ctx context.Context, conn net.PacketConn) {
+	defer s.wg.Done()
+
+	buf := make([]byte, 64*1024)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		n, src, err := conn.ReadFrom(buf)
+		if err != nil {
+			return
+		}
+
+		data := make([]byte, n)
+		copy(data, buf[:n])
+
+		// Extract IP without port
+		srcStr := src.String()
+		ip := srcStr
+		if host, _, err := net.SplitHostPort(srcStr); err == nil {
+			ip = host
+		}
+
+		// Handle the raw syslog packet
+		go s.handleLog(ctx, data, ip)
+	}
+}
+
+// listenTCP accepts connections and reads lines until ctx is canceled or the listener is closed.
+func (s *SyslogServer) listenTCP(ctx context.Context, ln net.Listener) {
+	defer s.wg.Done()
+
+	for {
+		// Check if we can accept more connections
+		s.connectionMutex.Lock()
+		if s.activeConnections >= s.maxConnections {
+			s.connectionMutex.Unlock()
+			// Wait before trying again
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(100 * time.Millisecond):
+				continue
+			}
+		}
+		s.activeConnections++
+		s.connectionMutex.Unlock()
+
+		// Accept with timeout to prevent blocking forever
+		deadline := time.Now().Add(5 * time.Second)
+		ln.(*net.TCPListener).SetDeadline(deadline)
+
+		conn, err := ln.Accept()
+		if err != nil {
+			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+				continue // Just a timeout, try again
+			}
+			// Other errors mean listener closed or fatal error
+			s.connectionMutex.Lock()
+			s.activeConnections--
+			s.connectionMutex.Unlock()
+			return
+		}
+
+		ip, _, err := net.SplitHostPort(conn.RemoteAddr().String())
+		if err != nil {
+			// Handle error
+			continue
+		}
+
+		s.connectionMutex.Lock()
+		ipCount := s.ipConnections[ip]
+		ipLimit := s.defaultIPLimit
+		if limit, ok := s.ipLimits[ip]; ok {
+			ipLimit = limit
+		}
+
+		if ipCount >= ipLimit {
+			s.connectionMutex.Unlock()
+			conn.Close() // Reject connection
+			continue
+		}
+
+		s.ipConnections[ip]++
+		s.connectionMutex.Unlock()
+
+		go s.handleTCPConn(ctx, conn)
+	}
+}
+
+// handleTCPConn reads syslog lines from a single connection.
+func (s *SyslogServer) handleTCPConn(ctx context.Context, conn net.Conn) {
+	defer func() {
+		conn.Close()
+		s.connectionMutex.Lock()
+		s.activeConnections--
+		s.connectionMutex.Unlock()
+	}()
+
+	// Set timeout for idle connections
+	conn.SetReadDeadline(time.Now().Add(30 * time.Second))
+
+	reader := bufio.NewReader(conn)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		line, err := reader.ReadBytes('\n')
+		if err != nil {
+			return
+		}
+
+		// Reset deadline after successful read
+		conn.SetReadDeadline(time.Now().Add(30 * time.Second))
+
+		// Wire in the handleLog helper
+		go s.handleLog(ctx, line, conn.RemoteAddr().String())
+	}
+}
+
+// Stop triggers a shutdown (via context cancellation upstream) and waits for both listeners.
+func (s *SyslogServer) Stop() {
+
+	s.wg.Wait()
+}


### PR DESCRIPTION
Added new syslog server package that creates a syslog listener on port (configurable) TCP/UDP. NetworkDevices are stored in datastore and syslog server only accepts traffic from devices in that registry. Logs are accepted in CEF / RFC3164 / RFC 5424 formats and written to log buffer -> logstore.

Now, network devices can be monitored and alerts/events can be triggered based on logs received.